### PR TITLE
Create div.c

### DIFF
--- a/maths/div.c
+++ b/maths/div.c
@@ -1,0 +1,38 @@
+/* This File is Part of LibFalcon.
+ * Copyright (c) 2018, Syed Nasim
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   * Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   * Neither the name of LibFalcon nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <ctype.h>
+#include <stdint.h>
+int32_t div(const int32_t a, const int32_t b) {
+  return a / b;
+}
+
+#if defined(__cplusplus)
+}
+#endif


### PR DESCRIPTION
Added function to handle division. Didn't handle divide by zero error, it'd be better to let it be handled by hardware which will return SIGSEGV (segmentation fault)
Alternatively let me know if you'd like me to add something like following for divide by zero case
`printf("Divide by zero error"); exit;`